### PR TITLE
Fix #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Select projectGenerator, select 'update project', then select the path of
 Open `example_aubioDemo.xcodeproject`, drag `aubio.framework` into to it,
 placing it in `frameworks / 3rd party frameworks`.
 
+### Linux
+
+Clone `ofxAubio` in your addons folder:
+
+    $ cd /path/to/of_root/addons
+    $ git clone git://git.aubio.org/git/ofxAubio/
+
+Install `aubio` library and headers, on Debian/Ubuntu:
+
+    $ sudo sudo apt-get install libaubio-dev
+
+In your project edit `config.make`:
+
+    PROJECT_LDFLAGS=-laubio
+
 Project Homepage
 ----------------
 

--- a/example_aubioDemo/Makefile
+++ b/example_aubioDemo/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=$(realpath ../../..)
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk

--- a/example_aubioDemo/config.make
+++ b/example_aubioDemo/config.make
@@ -1,0 +1,141 @@
+################################################################################
+# CONFIGURE PROJECT MAKEFILE (optional)
+#   This file is where we make project specific configurations.
+################################################################################
+
+################################################################################
+# OF ROOT
+#   The location of your root openFrameworks installation
+#       (default) OF_ROOT = ../../.. 
+################################################################################
+# OF_ROOT = ../../..
+
+################################################################################
+# PROJECT ROOT
+#   The location of the project - a starting place for searching for files
+#       (default) PROJECT_ROOT = . (this directory)
+#    
+################################################################################
+# PROJECT_ROOT = .
+
+################################################################################
+# PROJECT SPECIFIC CHECKS
+#   This is a project defined section to create internal makefile flags to 
+#   conditionally enable or disable the addition of various features within 
+#   this makefile.  For instance, if you want to make changes based on whether
+#   GTK is installed, one might test that here and create a variable to check. 
+################################################################################
+# None
+
+################################################################################
+# PROJECT EXTERNAL SOURCE PATHS
+#   These are fully qualified paths that are not within the PROJECT_ROOT folder.
+#   Like source folders in the PROJECT_ROOT, these paths are subject to 
+#   exlclusion via the PROJECT_EXLCUSIONS list.
+#
+#     (default) PROJECT_EXTERNAL_SOURCE_PATHS = (blank) 
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_EXTERNAL_SOURCE_PATHS = 
+
+################################################################################
+# PROJECT EXCLUSIONS
+#   These makefiles assume that all folders in your current project directory 
+#   and any listed in the PROJECT_EXTERNAL_SOURCH_PATHS are are valid locations
+#   to look for source code. The any folders or files that match any of the 
+#   items in the PROJECT_EXCLUSIONS list below will be ignored.
+#
+#   Each item in the PROJECT_EXCLUSIONS list will be treated as a complete 
+#   string unless teh user adds a wildcard (%) operator to match subdirectories.
+#   GNU make only allows one wildcard for matching.  The second wildcard (%) is
+#   treated literally.
+#
+#      (default) PROJECT_EXCLUSIONS = (blank)
+#
+#		Will automatically exclude the following:
+#
+#			$(PROJECT_ROOT)/bin%
+#			$(PROJECT_ROOT)/obj%
+#			$(PROJECT_ROOT)/%.xcodeproj
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_EXCLUSIONS =
+
+################################################################################
+# PROJECT LINKER FLAGS
+#	These flags will be sent to the linker when compiling the executable.
+#
+#		(default) PROJECT_LDFLAGS = -Wl,-rpath=./libs
+#
+#   Note: Leave a leading space when adding list items with the += operator
+#
+# Currently, shared libraries that are needed are copied to the 
+# $(PROJECT_ROOT)/bin/libs directory.  The following LDFLAGS tell the linker to
+# add a runtime path to search for those shared libraries, since they aren't 
+# incorporated directly into the final executable application binary.
+################################################################################
+PROJECT_LDFLAGS=-laubio
+
+################################################################################
+# PROJECT DEFINES
+#   Create a space-delimited list of DEFINES. The list will be converted into 
+#   CFLAGS with the "-D" flag later in the makefile.
+#
+#		(default) PROJECT_DEFINES = (blank)
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_DEFINES = 
+
+################################################################################
+# PROJECT CFLAGS
+#   This is a list of fully qualified CFLAGS required when compiling for this 
+#   project.  These CFLAGS will be used IN ADDITION TO the PLATFORM_CFLAGS 
+#   defined in your platform specific core configuration files. These flags are
+#   presented to the compiler BEFORE the PROJECT_OPTIMIZATION_CFLAGS below. 
+#
+#		(default) PROJECT_CFLAGS = (blank)
+#
+#   Note: Before adding PROJECT_CFLAGS, note that the PLATFORM_CFLAGS defined in 
+#   your platform specific configuration file will be applied by default and 
+#   further flags here may not be needed.
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_CFLAGS = 
+
+################################################################################
+# PROJECT OPTIMIZATION CFLAGS
+#   These are lists of CFLAGS that are target-specific.  While any flags could 
+#   be conditionally added, they are usually limited to optimization flags. 
+#   These flags are added BEFORE the PROJECT_CFLAGS.
+#
+#   PROJECT_OPTIMIZATION_CFLAGS_RELEASE flags are only applied to RELEASE targets.
+#
+#		(default) PROJECT_OPTIMIZATION_CFLAGS_RELEASE = (blank)
+#
+#   PROJECT_OPTIMIZATION_CFLAGS_DEBUG flags are only applied to DEBUG targets.
+#
+#		(default) PROJECT_OPTIMIZATION_CFLAGS_DEBUG = (blank)
+#
+#   Note: Before adding PROJECT_OPTIMIZATION_CFLAGS, please note that the 
+#   PLATFORM_OPTIMIZATION_CFLAGS defined in your platform specific configuration 
+#   file will be applied by default and further optimization flags here may not 
+#   be needed.
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_OPTIMIZATION_CFLAGS_RELEASE = 
+# PROJECT_OPTIMIZATION_CFLAGS_DEBUG = 
+
+################################################################################
+# PROJECT COMPILERS
+#   Custom compilers can be set for CC and CXX
+#		(default) PROJECT_CXX = (blank)
+#		(default) PROJECT_CC = (blank)
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_CXX = 
+# PROJECT_CC = 

--- a/example_aubioDemo/example_aubioDemo.qbs
+++ b/example_aubioDemo/example_aubioDemo.qbs
@@ -1,0 +1,57 @@
+import qbs
+import qbs.Process
+import qbs.File
+import qbs.FileInfo
+import qbs.TextFile
+import "../../../libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs" as ofApp
+
+Project{
+    property string of_root: "../../.."
+
+    ofApp {
+        name: { return FileInfo.baseName(path) }
+
+        files: [
+            'src/main.cpp',
+            'src/ofApp.cpp',
+            'src/ofApp.h',
+        ]
+
+        of.addons: [
+            'ofxAubio',
+            'ofxGui',
+        ]
+
+        // additional flags for the project. the of module sets some
+        // flags by default to add the core libraries, search paths...
+        // this flags can be augmented through the following properties:
+        of.pkgConfigs: []       // list of additional system pkgs to include
+        of.includePaths: []     // include search paths
+        of.cFlags: []           // flags passed to the c compiler
+        of.cxxFlags: []         // flags passed to the c++ compiler
+        of.linkerFlags: []      // flags passed to the linker
+        of.defines: []          // defines are passed as -D to the compiler
+                                // and can be checked with #ifdef or #if in the code
+
+        // other flags can be set through the cpp module: http://doc.qt.io/qbs/cpp-module.html
+        // eg: this will enable ccache when compiling
+        //
+        // cpp.compilerWrapper: 'ccache'
+
+        Depends{
+            name: "cpp"
+        }
+
+        // common rules that parse the include search paths, core libraries...
+        Depends{
+            name: "of"
+        }
+
+        // dependency with the OF library
+        Depends{
+            name: "openFrameworks"
+        }
+    }
+
+    references: [FileInfo.joinPaths(of_root, "/libs/openFrameworksCompiled/project/qtcreator/openFrameworks.qbs")]
+}


### PR DESCRIPTION
Added Linux section in `README.md`.
Runned `projectGenerator` on the example, now can be built with `make`.
