### PR TITLE
Added follow redirect flag for curl call inside the installation script and updated Aubio version to 0.4.4.

### DIFF
--- a/scripts/fetch_aubio_osx_framework.sh
+++ b/scripts/fetch_aubio_osx_framework.sh
@@ -8,6 +8,6 @@ set -e
 set -x
 
 rm -rf $AUBIO_ZIPFRAM example_aubioDemo/$AUBIO_FRAMPATH
-curl -O http://aubio.org/bin/$AUBIO_VERSION/$AUBIO_ZIPFRAM
+curl -OL http://aubio.org/bin/$AUBIO_VERSION/$AUBIO_ZIPFRAM
 unzip -x $AUBIO_ZIPFRAM -d example_aubioDemo/
 open example_aubioDemo/$AUBIO_FRAMPATH

--- a/scripts/fetch_aubio_osx_framework.sh
+++ b/scripts/fetch_aubio_osx_framework.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-AUBIO_VERSION=0.4.2
+AUBIO_VERSION=0.4.4
 AUBIO_ZIPFRAM=aubio-$AUBIO_VERSION.darwin_framework.zip
 AUBIO_FRAMPATH=${AUBIO_ZIPFRAM%%.zip}
 

--- a/scripts/fetch_aubio_osx_framework.sh
+++ b/scripts/fetch_aubio_osx_framework.sh
@@ -8,6 +8,6 @@ set -e
 set -x
 
 rm -rf $AUBIO_ZIPFRAM example_aubioDemo/$AUBIO_FRAMPATH
-curl -OL http://aubio.org/bin/$AUBIO_VERSION/$AUBIO_ZIPFRAM
+curl -OL https://aubio.org/bin/$AUBIO_VERSION/$AUBIO_ZIPFRAM
 unzip -x $AUBIO_ZIPFRAM -d example_aubioDemo/
 open example_aubioDemo/$AUBIO_FRAMPATH


### PR DESCRIPTION
Right now aubio redirects binary downloads to https and this breaks the curl command in the binary fetcher script. I've added the follow flag to the curl call so it follows redirections.